### PR TITLE
Set default key of the application to Home.

### DIFF
--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -68,7 +68,7 @@ const styles = theme => ({
 class ResponsiveDrawer extends React.Component {
     state = {
         mobileOpen: false,
-        key: '',
+        key: 'Home',
         open: false
     };
 


### PR DESCRIPTION
It was set to blank, which meant that the application wasn't on any page when the user first visits the application.